### PR TITLE
Add back config.ru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,3 @@
 
 # Ignore application configuration
 /config/application.yml
-
-config.ru

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+# This file is used by Rack-based servers to start the application.
+
+require ::File.expand_path('../config/environment',  __FILE__)
+run Rails.application


### PR DESCRIPTION
config.ru is necessary to run the server and generally should be in the repository. You may not want to merge this right away if you're doing something unusual in your local or prod environment that depends on this being ignored. Otherwise I'd recommend it.

If you merge via the web interface, you may want to rm/mv your local, ignored copy before pulling to prevent the possibility of a local merge conflict in your dev environment. (same potentially with prod)